### PR TITLE
fix(path_to_fire_bookmarks): exit early if not installed

### DIFF
--- a/src/chrom_bookmarks.py
+++ b/src/chrom_bookmarks.py
@@ -97,6 +97,8 @@ def path_to_fire_bookmarks():
     """
     user_dir = os.path.expanduser('~')
     f_home = user_dir + FIRE_BOOKMARKS
+    if not os.path.isdir(f_home):
+        return None
     f_home_dirs = ['{0}/{1}'.format(f_home, o) for o in os.listdir(f_home)]
     valid_hist = None
     for f in f_home_dirs:


### PR DESCRIPTION
I'm seeing this error if Firefox is not installed:
```
[11:17:41.842] ERROR: Chromium&Firefox Bookmarks and History[Script Filter] Code 1: Traceback (most recent call last):
  File ".../Alfred.alfredpreferences/workflows/user.workflow.3BAAF51C-BFEB-459B-83C4-59D524CCB3D0/chrom_bookmarks.py", line 177, in <module>
    fire_path = path_to_fire_bookmarks()
  File ".../Alfred.alfredpreferences/workflows/user.workflow.3BAAF51C-BFEB-459B-83C4-59D524CCB3D0/chrom_bookmarks.py", line 101, in path_to_fire_bookmarks
    f_home_dirs = ['{0}/{1}'.format(f_home, o) for o in os.listdir(f_home)]
OSError: [Errno 2] No such file or directory: '.../Library/Application Support/Firefox/Profiles'
```

**OS:** macOS 10.15.4
**Alfred:** 4.0.8
**Workflow:** https://github.com/Acidham/chromium-hist-bookmarks/blob/6112155e615363d3bbdc3403bae4762835badf35/Chromium%26Firefox%20Bookmarks%20and%20History.alfredworkflow