### PR TITLE
fix for brave beta (replacing dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 - Chromium
 - Google Chrome
-- Brave and Brave Dev(Chromium)
+- Brave and Brave beta (Chromium)
 - Vivaldi
 - Opera
 - Sidekick

--- a/src/chrom_bookmarks.py
+++ b/src/chrom_bookmarks.py
@@ -14,7 +14,7 @@ from Favicon import Icons
 
 BOOKMARS_MAP = {
     "brave": '/Library/Application Support/BraveSoftware/Brave-Browser/Default/Bookmarks',
-    "brave_dev": '/Library/Application Support/BraveSoftware/Brave-Browser-Dev/Default/Bookmarks',
+    "brave_beta": '/Library/Application Support/BraveSoftware/Brave-Browser-Beta/Default/Bookmarks',
     "chrome": '/Library/Application Support/Google/Chrome/Default/Bookmarks',
     "chromium": '/Library/Application Support/Chromium/Default/Bookmarks',
     "opera": '/Library/Application Support/com.operasoftware.Opera/Bookmarks',

--- a/src/chrom_history.py
+++ b/src/chrom_history.py
@@ -16,7 +16,7 @@ from Favicon import Icons
 
 HISTORY_MAP = {
     "brave": "/Library/Application Support/BraveSoftware/Brave-Browser/Default/History",
-    "brave_dev": "/Library/Application Support/BraveSoftware/Brave-Browser-Dev/Default/History",
+    "brave_beta": "/Library/Application Support/BraveSoftware/Brave-Browser-Beta/Default/History",
     "chromium": "/Library/Application Support/Chromium/Default/History",
     "chrome": "/Library/Application Support/Google/Chrome/Default/History",
     "opera": "/Library/Application Support/com.operasoftware.Opera/History",

--- a/src/info.plist
+++ b/src/info.plist
@@ -362,7 +362,7 @@ fi</string>
 
 - Chromium
 - Google Chrome
-- Brave and Brave Dev(Chromium)
+- Brave and Brave Beta (Chromium)
 - Vivaldi
 - Opera
 - Sidekick
@@ -497,7 +497,7 @@ Search Bookmarks with keyword: `bm`</string>
 				<key>required</key>
 				<false/>
 				<key>text</key>
-				<string>Brave Developer</string>
+				<string>Brave Beta</string>
 			</dict>
 			<key>description</key>
 			<string></string>
@@ -506,7 +506,7 @@ Search Bookmarks with keyword: `bm`</string>
 			<key>type</key>
 			<string>checkbox</string>
 			<key>variable</key>
-			<string>brave_dev</string>
+			<string>brave_beta</string>
 		</dict>
 		<dict>
 			<key>config</key>


### PR DESCRIPTION
Simple fix of replacing all references of `Brave Developer / Dev` with `Brave Beta`.
Additionally changes the path of bookmarks.