### PR TITLE
Fix double-encoding of URL fragments when opening bookmarks/history

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ This helps you quickly find where a bookmark is organized in your browser.
 
 ## Changelog
 
+### v4.5.7
+- Fix URLs with a fragment being re-encoded when opened (e.g. draw.io/diagrams.net links, where `#...%2F...#%7B` became `#...%252F...%23%257B` and the page failed to load)
+
 ### v4.5.6
 - Fix Helium browser history path (missing `/History` filename)
 

--- a/src/browser_dispatcher.py
+++ b/src/browser_dispatcher.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
-import os
-import subprocess
 import sys
 
 from Alfred3 import Tools
 from browser_config import BROWSER_APPS
+from url_opener import open_url
 
 
 def open_url_in_browser(app_path: str, url: str) -> bool:
@@ -19,22 +18,7 @@ def open_url_in_browser(app_path: str, url: str) -> bool:
     Returns:
         bool: True if successful, False otherwise
     """
-    # Check if the app exists
-    if not os.path.exists(app_path):
-        Tools.log(f"Browser app not found: {app_path}")
-        return False
-
-    try:
-        # Use 'open' command with -a flag to specify the application
-        subprocess.run(['open', '-a', app_path, url], check=True)
-        Tools.log(f"Successfully opened {url} in {app_path}")
-        return True
-    except subprocess.CalledProcessError as e:
-        Tools.log(f"Error opening URL in browser: {e}")
-        return False
-    except Exception as e:
-        Tools.log(f"Unexpected error: {e}")
-        return False
+    return open_url(url, app_path)
 
 
 def main():

--- a/src/info.plist
+++ b/src/info.plist
@@ -256,23 +256,25 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>browser</key>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>python3 open_url.py</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
 				<string></string>
-				<key>skipqueryencode</key>
-				<true/>
-				<key>skipvarencode</key>
-				<true/>
-				<key>spaces</key>
-				<string></string>
-				<key>url</key>
-				<string>{var:url}</string>
+				<key>type</key>
+				<integer>5</integer>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.action.openurl</string>
+			<string>alfred.workflow.action.script</string>
 			<key>uid</key>
 			<string>0899A9C0-908D-4A32-9061-8DC000FAC6E2</string>
 			<key>version</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -780,6 +782,8 @@ When viewing bookmarks, press `SHIFT` to see the bookmark's location in your bro
 	<dict>
 		<key>0899A9C0-908D-4A32-9061-8DC000FAC6E2</key>
 		<dict>
+			<key>note</key>
+			<string>Open URL in default browser (open_url.py)</string>
 			<key>xpos</key>
 			<real>1100</real>
 			<key>ypos</key>
@@ -1350,7 +1354,7 @@ OR = any term can match
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>
-	<string>4.5.6</string>
+	<string>4.5.7</string>
 	<key>webaddress</key>
 	<string>https://github.com/Acidham/chromium-hist-bookmarks</string>
 </dict>

--- a/src/open_url.py
+++ b/src/open_url.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+"""
+Open the selected URL in the default browser.
+
+Replaces Alfred's built in "Open URL" object, which routes through
+LaunchServices and therefore re-encodes fragments of URLs such as
+https://app.diagrams.net/#Hfoo%2Fbar.drawio#%7B%22pageId%22%3A%22x%22%7D
+See url_opener.py for details.
+"""
+
+import sys
+
+from Alfred3 import Tools
+from url_opener import open_url
+
+url = Tools.getEnv('url')
+
+if not url:
+    Tools.log("No URL provided in environment")
+    sys.exit(1)
+
+if not open_url(url):
+    sys.exit(1)

--- a/src/url_opener.py
+++ b/src/url_opener.py
@@ -1,0 +1,204 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+"""
+URL opening helpers.
+
+macOS LaunchServices (used by `open`, by AppleScript's `open location` and by
+Alfred's own "Open URL" object) re-percent-encodes the fragment of a URL when
+that fragment contains characters which are not legal in a fragment per
+RFC 3986 - most commonly a second "#". Re-encoding escapes the *whole* fragment,
+so already percent-encoded sequences are encoded a second time:
+
+    https://app.diagrams.net/#Hfoo%2Fbar.drawio#%7B%22pageId%22%3A%22x%22%7D
+ -> https://app.diagrams.net/#Hfoo%252Fbar.drawio%23%257B%2522pageId%2522%253A%2522x%2522%257D
+
+The browser then receives a different fragment than the one that was bookmarked
+and the page fails to load. Web apps that keep state in the fragment (draw.io,
+diagrams.net, many SPAs) hit this regularly.
+
+For those URLs we bypass LaunchServices and hand the URL straight to the
+browser executable as an argv, which passes it through untouched.
+"""
+
+import os
+import plistlib
+import re
+import subprocess
+
+from Alfred3 import Tools
+from browser_config import BROWSER_APPS
+
+# RFC 3986: fragment = *( pchar / "/" / "?" ), pchar = unreserved / pct-encoded
+# / sub-delims / ":" / "@". A fragment built only from these characters is left
+# alone by LaunchServices; anything else makes it re-encode the whole fragment.
+_SAFE_FRAGMENT = re.compile(r"^(?:[A-Za-z0-9\-._~!$&'()*+,;=:@/?]|%[0-9A-Fa-f]{2})*$")
+
+# Browsers that cannot be handed a URL on the command line. LaunchServices is
+# the only way in, so such URLs stay subject to the re-encoding described above.
+_NO_ARGV_BUNDLE_IDS = ("com.apple.safari",)
+
+
+def is_launchservices_safe(url: str) -> bool:
+    """
+    Check whether macOS LaunchServices would pass a URL through unchanged.
+
+    Args:
+        url (str): URL to check
+
+    Returns:
+        bool: True if `open` can be used without mangling the URL
+    """
+    fragment = url.partition('#')[2]
+    if not fragment:
+        return True
+    return bool(_SAFE_FRAGMENT.match(fragment))
+
+
+def get_bundle_id(app_path: str) -> str:
+    """
+    Read the bundle identifier of an application bundle.
+
+    Args:
+        app_path (str): Path to the .app bundle
+
+    Returns:
+        str: Bundle identifier, empty string if it cannot be read
+    """
+    try:
+        with open(os.path.join(app_path, 'Contents', 'Info.plist'), 'rb') as fp:
+            return plistlib.load(fp).get('CFBundleIdentifier', '')
+    except Exception as e:
+        Tools.log(f"Cannot read Info.plist of {app_path}: {e}")
+        return ''
+
+
+def get_app_executable(app_path: str) -> str:
+    """
+    Get the main executable of an application bundle.
+
+    Args:
+        app_path (str): Path to the .app bundle
+
+    Returns:
+        str: Path to the executable, empty string if it cannot be determined
+    """
+    try:
+        with open(os.path.join(app_path, 'Contents', 'Info.plist'), 'rb') as fp:
+            executable = plistlib.load(fp).get('CFBundleExecutable', '')
+    except Exception as e:
+        Tools.log(f"Cannot read Info.plist of {app_path}: {e}")
+        return ''
+    if not executable:
+        return ''
+    binary = os.path.join(app_path, 'Contents', 'MacOS', executable)
+    return binary if os.path.isfile(binary) else ''
+
+
+def get_default_browser_app() -> str:
+    """
+    Determine the app bundle registered as the default https handler.
+
+    Returns:
+        str: Path to the .app bundle, empty string if it cannot be determined
+    """
+    prefs = os.path.expanduser(
+        '~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist')
+    bundle_id = ''
+    try:
+        with open(prefs, 'rb') as fp:
+            handlers = plistlib.load(fp).get('LSHandlers', [])
+        for h in handlers:
+            if h.get('LSHandlerURLScheme') == 'https':
+                bundle_id = h.get('LSHandlerRoleAll', '')
+                break
+    except Exception as e:
+        Tools.log(f"Cannot read LaunchServices preferences: {e}")
+        return ''
+    if not bundle_id:
+        Tools.log("No default https handler configured, Safari is assumed")
+        return ''
+
+    # LaunchServices stores bundle ids lower cased, compare accordingly
+    bundle_id = bundle_id.lower()
+    # Known browsers first, this avoids a Spotlight query in the common case
+    for app_path in BROWSER_APPS.values():
+        if os.path.isdir(app_path) and get_bundle_id(app_path).lower() == bundle_id:
+            return app_path
+    try:
+        found = subprocess.run(
+            ['mdfind', f"kMDItemCFBundleIdentifier == '{bundle_id}'c"],
+            capture_output=True, text=True, timeout=5).stdout.splitlines()
+    except Exception as e:
+        Tools.log(f"mdfind for {bundle_id} failed: {e}")
+        return ''
+    for line in found:
+        if line.endswith('.app'):
+            return line
+    Tools.log(f"Cannot locate application for bundle id {bundle_id}")
+    return ''
+
+
+def _open_via_executable(app_path: str, url: str) -> bool:
+    """
+    Hand the URL to the browser executable directly, bypassing LaunchServices.
+
+    Args:
+        app_path (str): Path to the .app bundle
+        url (str): URL to open
+
+    Returns:
+        bool: True if the browser was launched
+    """
+    if get_bundle_id(app_path).lower() in _NO_ARGV_BUNDLE_IDS:
+        Tools.log(f"{app_path} does not accept URLs as argument")
+        return False
+    binary = get_app_executable(app_path)
+    if not binary:
+        return False
+    try:
+        subprocess.Popen(
+            [binary, url],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            start_new_session=True)
+    except Exception as e:
+        Tools.log(f"Error launching {binary}: {e}")
+        return False
+    # The executable opens the tab but does not necessarily raise the window
+    subprocess.run(['open', '-a', app_path], check=False)
+    Tools.log(f"Opened {url} via {binary}")
+    return True
+
+
+def open_url(url: str, app_path: str = '') -> bool:
+    """
+    Open a URL, in the given browser or in the default browser.
+
+    URLs that LaunchServices would rewrite are passed to the browser executable
+    directly so that the fragment survives unchanged.
+
+    Args:
+        url (str): URL to open
+        app_path (str, optional): Path to the browser .app bundle. Defaults to
+                                  the default browser.
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    if app_path and not os.path.exists(app_path):
+        Tools.log(f"Browser app not found: {app_path}")
+        return False
+
+    if not is_launchservices_safe(url):
+        target = app_path or get_default_browser_app()
+        if target and _open_via_executable(target, url):
+            return True
+        Tools.log(f"Falling back to `open`, {url} may get re-encoded")
+
+    cmd = ['open', '-a', app_path, url] if app_path else ['open', url]
+    try:
+        subprocess.run(cmd, check=True)
+    except Exception as e:
+        Tools.log(f"Error opening URL: {e}")
+        return False
+    Tools.log(f"Opened {url}" + (f" in {app_path}" if app_path else ''))
+    return True


### PR DESCRIPTION
## Problem

Bookmarks whose URL carries state in the fragment open with a mangled URL and the page fails to load.

Bookmarked:

```
https://app.diagrams.net/#Hfoo%2Fbar%2Fmain%2Fplan.drawio#%7B%22pageId%22%3A%22c0uSshCKa7J2IiCdvHWX%22%7D
```

Actually opened:

```
https://app.diagrams.net/#Hfoo%252Fbar%252Fmain%252Fplan.drawio%23%257B%2522pageId%2522%253A%2522c0uSshCKa7J2IiCdvHWX%2522%257D
```

## Cause

Not the workflow's Python — the bookmark file is read correctly and the Script Filter emits the URL verbatim. macOS LaunchServices re-percent-encodes the *whole* fragment when it contains a character that is illegal in a fragment per RFC 3986 (here: a second `#`), so existing escapes get escaped a second time (`%2F` → `%252F`, `#` → `%23`).

This affects every LaunchServices route — `open`, AppleScript `open location`, and Alfred's built-in **Open URL** object (`skipqueryencode`/`skipvarencode` do not help, the rewrite happens when the URL is resolved, not when the variable is substituted). Verified on macOS 15 by reading back the resulting tab URL:

| URL | via `open` |
| --- | --- |
| `https://example.com/#a%2Fb%22c` | unchanged |
| `https://example.com/#a%2Fb{c}` | → `#a%252Fb%7Bc%7D` |
| `https://example.com/#a%2Fb c` | → `#a%252Fb%20c` |

Passing the same URL as an argv to the browser executable preserves it exactly.

## Fix

New `url_opener.py`:

* `is_launchservices_safe(url)` — is the fragment within the RFC 3986 fragment grammar?
* if yes → `open` as before, no behaviour change for the overwhelming majority of URLs
* if no → resolve the target browser and launch its executable directly with the URL as argv, then `open -a` the app to raise its window

Wiring:

* the Enter action now runs `open_url.py` (resolves the default https handler from LaunchServices preferences) instead of the built-in **Open URL** object — same for the "Open Domain" branch that fed into it
* `browser_dispatcher.py` ("Open in Source Browser") uses the same helper
* Safari is excluded from the direct-argv path (its binary does not take URLs) and falls back to `open`

## Testing

Verified end to end on macOS 15.5 / Alfred 5 with Brave as the default browser, reading back the opened tab's URL via AppleScript:

* the draw.io bookmark above — opens byte-identical, page loads
* an ordinary `https://example.com/#plain-fragment` — unchanged path via `open`
* "Open in Source Browser" with the same draw.io URL — opens byte-identical

The repo has no test suite, so no tests were added; `is_launchservices_safe` is a pure function and easy to cover if one is introduced later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)